### PR TITLE
Allow both stores to be ignored if small or no constant given.

### DIFF
--- a/tests/test_catchmod.py
+++ b/tests/test_catchmod.py
@@ -1,5 +1,6 @@
 from pycatchmod import SoilMoistureDeficitStore, LinearStore, NonLinearStore, SubCatchment, Catchment
 import numpy as np
+import pytest
 
 
 def test_smd_store():
@@ -127,6 +128,28 @@ def test_nonlinear_store():
     np.testing.assert_allclose(V[-1]**2/C, np.array(store.previous_outflow), rtol=1e-3, atol=1e-10)
 
 
+def test_subcatchment_no_nonlinear():
+    """
+    Test SubCatchment initialiser correctly catches invalid or no nonlinear_storage_constants
+    """
+    n = 10
+    area = 100.0
+
+    subcatchment = SubCatchment(area, np.zeros(n), np.zeros(n), np.zeros(n), np.zeros(n),
+                                direct_percolation=0.2, potential_drying_constant=100, gradient_drying_curve=0.3,
+                                linear_storage_constant=0.5, nonlinear_storage_constant=None)
+
+    assert subcatchment.nonlinear_store is None
+
+    # Warning should be raised if a small or zero non-linear constant is given.
+    with pytest.warns(UserWarning):
+        subcatchment = SubCatchment(area, np.zeros(n), np.zeros(n), np.zeros(n), np.zeros(n),
+                            direct_percolation=0.2, potential_drying_constant=100, gradient_drying_curve=0.3,
+                            linear_storage_constant=0.5, nonlinear_storage_constant=0.0)
+
+        assert subcatchment.nonlinear_store is None
+
+
 def test_subcatchment():
     """
     Test SubCatchment can step correctly
@@ -134,7 +157,7 @@ def test_subcatchment():
     """
     n = 10
     area = 100.0
-    subcatchment = SubCatchment(100.0, np.zeros(n), np.zeros(n), np.zeros(n), np.zeros(n),
+    subcatchment = SubCatchment(area, np.zeros(n), np.zeros(n), np.zeros(n), np.zeros(n),
                                 direct_percolation=0.2, potential_drying_constant=100, gradient_drying_curve=0.3,
                                 linear_storage_constant=0.5, nonlinear_storage_constant=10.0)
 

--- a/tests/test_catchmod.py
+++ b/tests/test_catchmod.py
@@ -128,6 +128,27 @@ def test_nonlinear_store():
     np.testing.assert_allclose(V[-1]**2/C, np.array(store.previous_outflow), rtol=1e-3, atol=1e-10)
 
 
+def test_subcatchment_no_linear():
+    """
+    Test SubCatchment initialiser correctly catches invalid or no nonlinear_storage_constants
+    """
+    n = 10
+    area = 100.0
+
+    subcatchment = SubCatchment(area, np.zeros(n), np.zeros(n), np.zeros(n), np.zeros(n),
+                                direct_percolation=0.2, potential_drying_constant=100, gradient_drying_curve=0.3,
+                                linear_storage_constant=None, nonlinear_storage_constant=10.0)
+
+    assert subcatchment.linear_store is None
+
+    # Warning should be raised if a small or zero non-linear constant is given.
+    with pytest.warns(UserWarning):
+        subcatchment = SubCatchment(area, np.zeros(n), np.zeros(n), np.zeros(n), np.zeros(n),
+                            direct_percolation=0.2, potential_drying_constant=100, gradient_drying_curve=0.3,
+                            linear_storage_constant=0.0, nonlinear_storage_constant=10.0)
+
+        assert subcatchment.linear_store is None
+
 def test_subcatchment_no_nonlinear():
     """
     Test SubCatchment initialiser correctly catches invalid or no nonlinear_storage_constants


### PR DESCRIPTION
This PR means a `SubCatchment` will not create a `Linear` or `NonLinearStore` if the respective constant is small (<= 1e-12) or `None`. If a small float is given a warning is given to the user.