### PR TITLE
Make catchment_from_json more robust to input types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pandas cython pytest
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pandas cython pytest future
   - source activate test-environment
   - python setup.py install
 

--- a/pycatchmod/utils.py
+++ b/pycatchmod/utils.py
@@ -1,13 +1,21 @@
 import json
 import numpy as np
 from ._catchmod import Catchment, SubCatchment, OudinCatchment
-
+from past.builtins import basestring
 
 def catchment_from_json(filename, n=1):
-
-    with open(filename) as fh:
-        data = json.load(fh)
-
+    if isinstance(filename, dict):
+        # argument is already a python dictionary
+        data = filename
+    elif isinstance(filename, basestring):
+        # argument is a filename
+        with open(filename) as fh:
+            data = json.load(fh)
+    elif hasattr(filename, "read"):
+        # argument is file-like
+        data = json.load(filename.read())
+    else:
+        raise TypeError("Unexpected input type: \"{}\"".format(filename.__class__.__name__))
 
     subcatchments = []
     for subdata in data['subcatchments']:


### PR DESCRIPTION
`catchment_from_json` can now accept the parameters as a filename, a pre-parsed dictionary, or a file handle.